### PR TITLE
Fix compilation on Windows.

### DIFF
--- a/src/mode.rs
+++ b/src/mode.rs
@@ -1,8 +1,10 @@
 use std::fmt::{self, Display, Formatter, Write};
+use std::io;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not};
 use std::path::Path;
-use std::{fs, io};
 
+#[cfg(unix)]
+use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 
@@ -122,13 +124,17 @@ impl Mode {
     }
     /// return the mode for the given path.
     /// On non unix platforms, return `Mode::all()`
+    #[allow(unused_variables)]
     pub fn try_from(path: &Path) -> Result<Self, io::Error> {
-        Ok(if cfg!(unix) {
-            let metadata = fs::metadata(&path)?;
-            Mode::from(metadata.mode())
-        } else {
-            Self::all() // well, let's assume everything is permitted
-        })
+        match () {
+            #[cfg(unix)]
+            () => {
+                let metadata = fs::metadata(&path)?;
+                Ok(Mode::from(metadata.mode()))
+            }
+            #[cfg(not(unix))]
+            () => Ok(Self::all()),
+        }
     }
     /// finds if the mode indicates an executable file
     #[inline(always)]


### PR DESCRIPTION
Hello,

I was trying to compile broot on Windows and it failed with the following error:
```
error[E0599]: no method named `mode` found for type `std::fs::Metadata` in the current scope
   --> src\mode.rs:128:33
    |
128 |             Mode::from(metadata.mode())
    |
```

The reason, if anyone reading this wants know, is that `cfg!(unix)` evaluates to a boolean constant. Both branches must compile because the dead branch is only pruned during optimization, after resolving symbols, typechecking, etc.

I use the trick with match arms because it's not possible to have `cfg` attributes on expressions. The alternative would be to put it on the function, but the signature and documentation would need to be duplicated.

Thank you
Simon